### PR TITLE
Add simple password protection to Streamlit app

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -7,6 +7,10 @@ from sqlalchemy import create_engine
 import streamlit as st
 import plotly.express as px
 import ccxt
+from dotenv import load_dotenv, find_dotenv
+
+dotenv_path = find_dotenv(usecwd=True)
+load_dotenv(dotenv_path=dotenv_path if dotenv_path else None, override=False)
 
 DB_URL = os.getenv("DB_URL", "sqlite:///pnl.db")
 eng = create_engine(DB_URL, future=True)
@@ -75,6 +79,38 @@ def spot_to_usd(quotes):
 
 # --- UI ---
 st.set_page_config(page_title="Crypto P&L Tracker", layout="wide")
+
+APP_USERNAME = os.getenv("APP_USERNAME")
+APP_PASSWORD = os.getenv("APP_PASSWORD")
+
+if not APP_PASSWORD:
+    st.error(
+        "Aucun mot de passe n'est configuré pour l'application. "
+        "Définis la variable d'environnement `APP_PASSWORD` avant de lancer Streamlit."
+    )
+    st.stop()
+
+if "authenticated" not in st.session_state:
+    st.session_state.authenticated = False
+
+if not st.session_state.authenticated:
+    st.title("🔐 Accès protégé")
+    with st.form("login"):
+        if APP_USERNAME:
+            username = st.text_input("Utilisateur")
+        password = st.text_input("Mot de passe", type="password")
+        submit = st.form_submit_button("Se connecter")
+
+    if submit:
+        user_ok = True if not APP_USERNAME else username.strip() == APP_USERNAME
+        if user_ok and password == APP_PASSWORD:
+            st.session_state.authenticated = True
+            st.experimental_rerun()
+        else:
+            st.error("Identifiants invalides.")
+
+    st.stop()
+
 st.title("📈 Crypto P&L Tracker")
 
 df = load_trades()


### PR DESCRIPTION
## Summary
- gate the Streamlit dashboard behind a simple login form using session state
- require an APP_PASSWORD environment variable and optionally APP_USERNAME
- prevent access to the rest of the UI until the correct credentials are provided
- load environment variables from a .env file before validating credentials so configured passwords are picked up

## Testing
- python -m compileall ui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d4ef19d1048327bc9a4ed5e00dd2c5