### PR TITLE
Handle Streamlit rerun API change after login

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -105,7 +105,10 @@ if not st.session_state.authenticated:
         user_ok = True if not APP_USERNAME else username.strip() == APP_USERNAME
         if user_ok and password == APP_PASSWORD:
             st.session_state.authenticated = True
-            st.experimental_rerun()
+            if hasattr(st, "rerun"):
+                st.rerun()
+            else:
+                st.experimental_rerun()
         else:
             st.error("Identifiants invalides.")
 


### PR DESCRIPTION
## Summary
- call `st.rerun()` when available so the login flow works with recent Streamlit releases
- keep a fallback to `st.experimental_rerun()` for older Streamlit versions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5fe18112c8327bda6e26d57e4287d