### PR TITLE
Ensure ingest scripts can import application modules

### DIFF
--- a/scripts/ingest_binance.py
+++ b/scripts/ingest_binance.py
@@ -1,9 +1,19 @@
-import os, time
+import os
+import sys
+import time
 from datetime import datetime, timezone
+from pathlib import Path
+
 from dotenv import load_dotenv
 
 import ccxt
 from sqlalchemy.exc import SQLAlchemyError
+
+
+# Ensure the repository root (which contains the ``app`` package) is on PYTHONPATH
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from app.models import Trade, make_session
 

--- a/scripts/ingest_kraken.py
+++ b/scripts/ingest_kraken.py
@@ -1,11 +1,19 @@
 # scripts/ingest_kraken.py
 import os
+import sys
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 import ccxt
 from dotenv import load_dotenv
 from sqlalchemy.exc import SQLAlchemyError
+
+
+# Ensure the repository root (which contains the ``app`` package) is on PYTHONPATH
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from app.models import Trade, make_session
 

--- a/scripts/ingest_onchain.py
+++ b/scripts/ingest_onchain.py
@@ -1,5 +1,14 @@
 """CLI utility to ingest on-chain Ethereum data."""
 
+from pathlib import Path
+import sys
+
+
+# Ensure the repository root (which contains the ``app`` package) is on PYTHONPATH
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from app.ingest import onchain_eth
 
 


### PR DESCRIPTION
## Summary
- prepend the repository root to sys.path in the Binance, Kraken, and on-chain ingestion scripts so that the app package can be imported when the scripts are executed directly

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68d604f66be88327b3d87d18d98aaaf2