### PR TITLE
Add portfolio net value visualization

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,13 @@
-from sqlalchemy import create_engine, Column, String, Integer, Float, DateTime, UniqueConstraint
+from sqlalchemy import (
+    create_engine,
+    Column,
+    String,
+    Integer,
+    Float,
+    DateTime,
+    UniqueConstraint,
+    Date,
+)
 from sqlalchemy.orm import declarative_base, sessionmaker
 from datetime import datetime
 
@@ -18,6 +27,20 @@ class Trade(Base):
     iso = Column(DateTime)                  # UTC datetime
 
     __table_args__ = (UniqueConstraint('id', name='uq_trade_id'),)
+
+
+class AssetPrice(Base):
+    __tablename__ = "asset_prices"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    asset = Column(String, index=True, nullable=False)
+    day = Column(Date, index=True, nullable=False)
+    price_usd = Column(Float, nullable=False)
+    symbol = Column(String, nullable=True)
+    source = Column(String, nullable=True)
+
+    __table_args__ = (UniqueConstraint('asset', 'day', name='uq_asset_day'),)
+
 
 def make_session(db_url: str):
     eng = create_engine(db_url, future=True)

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,7 +1,9 @@
 import os
+import sys
 import subprocess
 from datetime import datetime, timezone, time as dtime, timedelta
 from collections import deque, defaultdict
+from pathlib import Path
 
 import pandas as pd
 from sqlalchemy import create_engine, select
@@ -10,6 +12,10 @@ import streamlit as st
 import plotly.express as px
 import ccxt
 from dotenv import load_dotenv, find_dotenv
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
 
 from app.models import Base, AssetPrice
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv, find_dotenv
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
-    sys.path.append(str(ROOT))
+    sys.path.insert(0, str(ROOT))
 
 from app.models import Base, AssetPrice
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -205,7 +205,10 @@ def ensure_price_history(assets, start_day, end_day):
             if not rows:
                 failed.add(asset)
                 continue
+            missing_days = missing_assets[asset]
             for row in rows:
+                if row["day"] not in missing_days:
+                    continue
                 session.merge(
                     AssetPrice(
                         asset=row["asset"],

--- a/ui/app.py
+++ b/ui/app.py
@@ -627,14 +627,32 @@ else:
                             .groupby("asset", as_index=False)["value_usd"].sum()
                         )
                         latest_alloc = latest_alloc[latest_alloc["value_usd"].abs() > 0]
+
                         if not latest_alloc.empty:
-                            fig_alloc = px.pie(
-                                latest_alloc,
-                                names="asset",
-                                values="value_usd",
-                                title="Répartition du portefeuille (USD)",
-                            )
-                            st.plotly_chart(fig_alloc, use_container_width=True)
+                            pos_alloc = latest_alloc[latest_alloc["value_usd"] > 0]
+                            neg_alloc = latest_alloc[latest_alloc["value_usd"] < 0]
+
+                            if not pos_alloc.empty:
+                                fig_alloc = px.pie(
+                                    pos_alloc,
+                                    names="asset",
+                                    values="value_usd",
+                                    title="Répartition du portefeuille (USD)",
+                                )
+                                st.plotly_chart(fig_alloc, use_container_width=True)
+                            else:
+                                st.info(
+                                    "Aucune position positive à représenter en camembert pour la dernière journée."
+                                )
+
+                            if not neg_alloc.empty:
+                                st.caption(
+                                    "Positions nettes négatives (exposées comme dettes ou shorts) non incluses dans le camembert :"
+                                )
+                                st.dataframe(
+                                    neg_alloc.rename(columns={"value_usd": "value_usd_neg"}),
+                                    use_container_width=True,
+                                )
                         else:
                             st.info("Aucune répartition à afficher pour la dernière journée.")
                     else:


### PR DESCRIPTION
## Summary
- reuse cached quote-to-USD rates when summarising realized PnL
- compute cumulative positions per symbol and derive USD net value
- render a portfolio net value line chart in the Streamlit dashboard

## Testing
- python -m py_compile ui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d60e369cfc8327883f297a12f46a40