### PR TITLE
Add support for ingesting Binance deposit and withdrawal records

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -42,6 +42,25 @@ class AssetPrice(Base):
     __table_args__ = (UniqueConstraint('asset', 'day', name='uq_asset_day'),)
 
 
+class Transfer(Base):
+    __tablename__ = "transfers"
+
+    id = Column(String, primary_key=True)
+    exchange = Column(String, index=True, nullable=False)
+    direction = Column(String, index=True, nullable=False)  # deposit / withdraw
+    asset = Column(String, index=True, nullable=True)
+    amount = Column(Float)
+    fee = Column(Float)
+    fee_currency = Column(String, nullable=True)
+    status = Column(String, nullable=True)
+    address = Column(String, nullable=True)
+    txid = Column(String, nullable=True)
+    ts = Column(Integer, index=True)
+    iso = Column(DateTime)
+
+    __table_args__ = (UniqueConstraint('id', name='uq_transfer_id'),)
+
+
 def make_session(db_url: str):
     eng = create_engine(db_url, future=True)
     Base.metadata.create_all(eng)

--- a/scripts/ingest_binance.py
+++ b/scripts/ingest_binance.py
@@ -15,7 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from app.models import Trade, make_session
+from app.models import Trade, Transfer, make_session
 
 load_dotenv()
 DB_URL = os.getenv("DB_URL", "sqlite:///pnl.db")
@@ -54,7 +54,41 @@ def upsert_trade(t):
     )
     session.merge(row)
 
-def ingest():
+
+def upsert_transfer(tx, direction: str):
+    ts = int(tx.get('timestamp') or 0)
+    fee_info = tx.get('fee') or {}
+    fee_cost = fee_info.get('cost') if isinstance(fee_info, dict) else 0.0
+    fee_currency = fee_info.get('currency') if isinstance(fee_info, dict) else None
+
+    info = tx.get('info') or {}
+    raw_identifier = (
+        tx.get('id')
+        or tx.get('txid')
+        or tx.get('txId')
+        or info.get('id')
+        or info.get('tranId')
+        or info.get('applyTime')
+        or f"{ts}_{tx.get('currency') or tx.get('code')}_{tx.get('amount')}_{tx.get('address')}"
+    )
+
+    row = Transfer(
+        id=f"binance_{direction}_{raw_identifier}",
+        exchange="binance",
+        direction=direction,
+        asset=tx.get('currency') or tx.get('code'),
+        amount=float(tx.get('amount') or 0.0),
+        fee=float(fee_cost or 0.0),
+        fee_currency=fee_currency,
+        status=tx.get('status'),
+        address=tx.get('address') or tx.get('toAddress') or tx.get('addressFrom'),
+        txid=tx.get('txid') or tx.get('txId'),
+        ts=ts,
+        iso=datetime.fromtimestamp(ts / 1000, tz=timezone.utc) if ts else None,
+    )
+    session.merge(row)
+
+def ingest_trades():
     count = 0
     # Parcourt tous les symbols connus ; seuls ceux où tu as tradé renverront des lignes
     for sym in ex.symbols:
@@ -67,7 +101,7 @@ def ingest():
                 upsert_trade(t)
                 count += 1
             session.commit()
-            time.sleep(ex.rateLimit/1000)
+            time.sleep(ex.rateLimit / 1000)
         except ccxt.BaseError:
             session.rollback()
             continue
@@ -76,6 +110,42 @@ def ingest():
             continue
     return count
 
+
+def ingest_transfers(fetcher, direction: str) -> int:
+    try:
+        batch = fetcher(limit=500)
+    except ccxt.BaseError as exc:
+        print(f"⚠️  Binance API error ({direction}): {exc}")
+        return 0
+
+    if not batch:
+        return 0
+
+    total = 0
+    try:
+        for tx in batch:
+            upsert_transfer(tx, direction)
+            total += 1
+        session.commit()
+    except SQLAlchemyError as exc:
+        session.rollback()
+        print(f"⚠️  DB error while storing {direction}s: {exc}")
+        return 0
+    finally:
+        time.sleep(ex.rateLimit / 1000)
+
+    return total
+
 if __name__ == "__main__":
-    total = ingest()
-    print(f"✅ Binance ingestion terminée. {total} trades insérés/à jour.")
+    trades = deposits = withdrawals = 0
+    try:
+        trades = ingest_trades()
+        deposits = ingest_transfers(ex.fetch_deposits, "deposit")
+        withdrawals = ingest_transfers(ex.fetch_withdrawals, "withdraw")
+    finally:
+        session.close()
+
+    print(
+        "✅ Binance ingestion terminée. "
+        f"{trades} trades, {deposits} dépôts et {withdrawals} retraits insérés/à jour."
+    )

--- a/scripts/ingest_kraken.py
+++ b/scripts/ingest_kraken.py
@@ -141,12 +141,14 @@ def ingest_all_trades():
 
 PERMISSION_HINTS = {
     "deposit": (
-        "Activez les autorisations Kraken “Funding → Consulter les dépôts” "
-        "et régénérez la clé si vous venez de modifier les droits."
+        "Activez les autorisations Kraken “Funding → Consulter les dépôts” et "
+        "“Ledger → Consulter les écritures” puis régénérez la clé si vous venez de "
+        "modifier les droits."
     ),
     "withdraw": (
-        "Activez les autorisations Kraken “Funding → Consulter les retraits” "
-        "et régénérez la clé si vous venez de modifier les droits."
+        "Activez les autorisations Kraken “Funding → Consulter les retraits” et "
+        "“Ledger → Consulter les écritures” puis régénérez la clé si vous venez de "
+        "modifier les droits."
     ),
 }
 

--- a/scripts/ingest_kraken.py
+++ b/scripts/ingest_kraken.py
@@ -143,7 +143,15 @@ def ingest_transfers(fetcher, direction: str) -> int:
     try:
         batch = fetcher(limit=500)
     except ccxt.BaseError as e:
-        print(f"⚠️  Kraken API error ({direction}): {e}")
+        message = str(e)
+        lowered = message.lower()
+        if "permission denied" in lowered:
+            print(
+                "ℹ️  Kraken n'a pas les permissions nécessaires pour "
+                f"récupérer les {direction}s. Vérifiez les droits de la clé API."
+            )
+        else:
+            print(f"⚠️  Kraken API error ({direction}): {message}")
         return 0
 
     if not batch:

--- a/scripts/ingest_kraken.py
+++ b/scripts/ingest_kraken.py
@@ -139,6 +139,18 @@ def ingest_all_trades():
     return total
 
 
+PERMISSION_HINTS = {
+    "deposit": (
+        "Activez les autorisations Kraken “Funding → Consulter les dépôts” "
+        "et régénérez la clé si vous venez de modifier les droits."
+    ),
+    "withdraw": (
+        "Activez les autorisations Kraken “Funding → Consulter les retraits” "
+        "et régénérez la clé si vous venez de modifier les droits."
+    ),
+}
+
+
 def ingest_transfers(fetcher, direction: str) -> int:
     try:
         batch = fetcher(limit=500)
@@ -146,9 +158,14 @@ def ingest_transfers(fetcher, direction: str) -> int:
         message = str(e)
         lowered = message.lower()
         if "permission denied" in lowered:
+            hint = PERMISSION_HINTS.get(
+                direction,
+                "Activez les autorisations Kraken Funding pour cette opération et "
+                "régénérez la clé si nécessaire.",
+            )
             print(
                 "ℹ️  Kraken n'a pas les permissions nécessaires pour "
-                f"récupérer les {direction}s. Vérifiez les droits de la clé API."
+                f"récupérer les {direction}s. {hint}"
             )
         else:
             print(f"⚠️  Kraken API error ({direction}): {message}")

--- a/ui/app.py
+++ b/ui/app.py
@@ -348,10 +348,10 @@ st.subheader("🔄 Mise à jour des données")
 update_feedback = None
 controls = st.columns(2)
 with controls[0]:
-    if st.button("Mettre à jour Binance", use_container_width=True):
+    if st.button("Mettre à jour Binance", width="stretch"):
         update_feedback = run_ingestion("scripts/ingest_binance.py", "Binance")
 with controls[1]:
-    if st.button("Mettre à jour Kraken", use_container_width=True):
+    if st.button("Mettre à jour Kraken", width="stretch"):
         update_feedback = run_ingestion("scripts/ingest_kraken.py", "Kraken")
 
 if update_feedback:
@@ -435,9 +435,9 @@ if not summary.empty:
     with c2:
         top = summary.nlargest(10, "pnl_USD_est") if "pnl_USD_est" in summary else summary.nlargest(10, "pnl_quote")
         fig = px.bar(top, x="symbol", y="pnl_USD_est", title="Top P&L (USD estimé)")
-        st.plotly_chart(fig, use_container_width=True)
+        st.plotly_chart(fig, width="stretch")
     with c3:
-        st.dataframe(summary, use_container_width=True, height=400)
+        st.dataframe(summary, width="stretch", height=400)
 else:
     st.info("Pas encore de P&L réalisé dans la période/filtres.")
 
@@ -614,7 +614,7 @@ else:
                         markers=True,
                         title="Valeur nette du portefeuille (USD)",
                     )
-                    st.plotly_chart(fig_value, use_container_width=True)
+                    st.plotly_chart(fig_value, width="stretch")
 
                     allocation_detail = pd.concat(
                         [base_valuations_detail, cash_valuations_detail], ignore_index=True
@@ -639,7 +639,7 @@ else:
                                     values="value_usd",
                                     title="Répartition du portefeuille (USD)",
                                 )
-                                st.plotly_chart(fig_alloc, use_container_width=True)
+                                st.plotly_chart(fig_alloc, width="stretch")
                             else:
                                 st.info(
                                     "Aucune position positive à représenter en camembert pour la dernière journée."
@@ -651,7 +651,7 @@ else:
                                 )
                                 st.dataframe(
                                     neg_alloc.rename(columns={"value_usd": "value_usd_neg"}),
-                                    use_container_width=True,
+                                    width="stretch",
                                 )
                         else:
                             st.info("Aucune répartition à afficher pour la dernière journée.")
@@ -662,7 +662,7 @@ st.subheader("Trades")
 st.dataframe(
     dff[["datetime","exchange","symbol","side","amount","price","fee","fee_currency"]]
       .sort_values("datetime", ascending=False),
-    use_container_width=True, height=420
+    width="stretch", height=420
 )
 
 st.subheader("Activité")
@@ -670,10 +670,10 @@ st.subheader("Activité")
 dff["day"] = dff["datetime"].dt.date
 by_day = dff.groupby(["day"]).size().reset_index(name="trades")
 fig2 = px.line(by_day, x="day", y="trades", title="Nombre de trades par jour")
-st.plotly_chart(fig2, use_container_width=True)
+st.plotly_chart(fig2, width="stretch")
 
 # Notional échangé par jour (approx amount*price, somme absolue)
 dff["notional"] = (dff["amount"].abs() * dff["price"].abs())
 notional = dff.groupby(["day"]).agg({"notional":"sum"}).reset_index()
 fig3 = px.bar(notional, x="day", y="notional", title="Notional échangé par jour (approx)")
-st.plotly_chart(fig3, use_container_width=True)
+st.plotly_chart(fig3, width="stretch")


### PR DESCRIPTION
## Summary
- add a Transfer SQLAlchemy model to persist deposit and withdrawal metadata
- extend the Binance ingestion script to fetch deposits and withdrawals alongside trades
- persist fetched transfers with robust identifiers and error handling for API/DB failures

## Testing
- python -m compileall app scripts

------
https://chatgpt.com/codex/tasks/task_e_68d639e69ad08327a952c6213972eb2d